### PR TITLE
Improve Instance Assignment Code

### DIFF
--- a/api/problem.py
+++ b/api/problem.py
@@ -149,7 +149,6 @@ def insert_problem(problem):
         # problem is already inserted, so update instead
         old_problem = get_problem(pid=problem["pid"])
         problem["disabled"] = old_problem["disabled"]
-        assert len(problem["instances"]) >= len(old_problem["instances"]), "Cannot update problem with fewer instances."
         update_problem(problem["pid"], problem)
         return
 
@@ -231,13 +230,14 @@ def search_problems(*conditions):
 
     return list(db.problems.find({"$or": list(conditions)}, {"_id":0}))
 
-def assign_instance_to_team(pid, tid=None):
+def assign_instance_to_team(pid, tid=None, reassign=False):
     """
     Assigns an instance of problem pid to team tid. Updates it in the database.
 
     Args:
         pid: the problem id
         tid: the team id
+        reassign: whether or not we should assign over an old assignment
 
     Returns:
         The iid that was assigned
@@ -246,8 +246,11 @@ def assign_instance_to_team(pid, tid=None):
     team = api.team.get_team(tid=tid)
     problem = get_problem(pid=pid)
 
-    if pid in team["instances"]:
+    if pid in team["instances"] and not reassign:
         raise InternalException("Team with tid {} already has an instance of pid {}.".format(tid, pid))
+
+    if len(problem["instances"]) == 0:
+        raise InternalException("Problem {} has no instances to assign.".format(pid))
 
     instance_number = randint(0, len(problem["instances"]) - 1)
     iid = problem["instances"][instance_number]["iid"]
@@ -283,7 +286,9 @@ def get_instance_data(pid, tid):
         if instance["iid"] == iid:
             return instance
 
-    raise SevereInternalException("Instance id {} for problem {} cannot be found!".format(iid, problem['name']))
+    # Cannot find assigned instance. Reassign instance and recurse.
+    assign_instance_to_team(pid, tid, reassign=True)
+    return get_instance_data(pid, tid)
 
 def get_problem_instance(pid, tid):
     """


### PR DESCRIPTION
This PR improves instance assignment, mainly by adding logic to re-assign instances if they no longer exist in the database. Further, I removed an incorrect check that was preventing loading problems from multiple shell servers.

Closes #14 