### PR TITLE
  Problem instance changes

### DIFF
--- a/api/problem.py
+++ b/api/problem.py
@@ -68,8 +68,6 @@ instance_schema = Schema({
         ("The description must be a string.", [str])),
     Required("flag"): check(
         ("The flag must be a string.", [str])),
-    Required("iid"): check(
-        ("The iid must be a string", [str])),
     "port": check(
         ("The port must be an int", [int])),
     "server": check(
@@ -115,7 +113,16 @@ def get_all_categories(show_disabled=False):
 
     return db.problems.find(match).distinct("category")
 
-def insert_problem(problem):
+
+def set_instance_ids(problem, sid):
+    """
+    Generate the instance ids for a set of problems.
+    """
+
+    for instance in problem["instances"]:
+        instance["iid"] = api.common.hash(instance["instance_number"] + sid + problem["pid"])
+
+def insert_problem(problem, sid=None):
     """
     Inserts a problem into the database. Does sane validation.
 
@@ -138,18 +145,19 @@ def insert_problem(problem):
     db = api.common.get_conn()
     validate(problem_schema, problem)
 
-    for instance in problem["instances"]:
-        validate(instance_schema, instance)
-
     # initially disable problems
     problem["disabled"] = True
     problem["pid"] = api.common.hash("{}-{}".format(problem["name"], problem["author"]))
+
+    for instance in problem["instances"]:
+        validate(instance_schema, instance)
+
+    set_instance_ids(problem, sid)
 
     if safe_fail(get_problem, pid=problem["pid"]) is not None:
         # problem is already inserted, so update instead
         old_problem = get_problem(pid=problem["pid"])
         problem["disabled"] = old_problem["disabled"]
-        assert len(problem["instances"]) >= len(old_problem["instances"]), "Cannot update problem with fewer instances."
         update_problem(problem["pid"], problem)
         return
 
@@ -841,7 +849,7 @@ def load_published(data):
         raise WebException("Please provide a problems list in your json.")
 
     for problem in data["problems"]:
-        insert_problem(problem)
+        insert_problem(problem, sid=data["sid"])
 
     if "bundles" in data:
         db = api.common.get_conn()

--- a/api/problem.py
+++ b/api/problem.py
@@ -120,7 +120,7 @@ def set_instance_ids(problem, sid):
     """
 
     for instance in problem["instances"]:
-        instance["iid"] = api.common.hash(instance["instance_number"] + sid + problem["pid"])
+        instance["iid"] = api.common.hash(str(instance["instance_number"]) + sid + problem["pid"])
 
 def insert_problem(problem, sid=None):
     """

--- a/api/setup.py
+++ b/api/setup.py
@@ -25,6 +25,10 @@ def index_mongo():
     db.ssh.ensure_index("tid", unique=True, name="unique ssh tid")
     db.teams.ensure_index("team_name", unique=True, name="unique team names")
 
+
+    db.shell_servers.ensure_index("name", unique=True, name="unique shell name")
+    db.shell_servers.ensure_index("sid", unique=True, name="unique shell sid")
+
     db.cache.ensure_index("expireAt", expireAfterSeconds=0)
     db.cache.ensure_index("kwargs", name="kwargs")
     db.cache.ensure_index("args", name="args")

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -193,6 +193,15 @@ def get_problem_status_from_server(sid):
 
     return (all_online, data)
 
+def set_instance_ids(sid, problems):
+    """
+    Generate the instance ids for a set of problems.
+    """
+
+    for problem in problems:
+        for instance in problem["instances"]:
+            instance["iid"] = api.common.hash(instance["instance_number"] + sid + problem["name"])
+
 def load_problems_from_server(sid):
     """
     Connects to the server and loads the problems from its deployment state.
@@ -210,6 +219,8 @@ def load_problems_from_server(sid):
 
     result = shell.run(["sudo", "shell_manager", "publish"])
     data = json.loads(result.output.decode("utf-8"))
+
+    set_instance_ids(data["problems"])
     api.problem.load_published(data)
 
     return len(data["problems"])

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -193,15 +193,6 @@ def get_problem_status_from_server(sid):
 
     return (all_online, data)
 
-def set_instance_ids(sid, problems):
-    """
-    Generate the instance ids for a set of problems.
-    """
-
-    for problem in problems:
-        for instance in problem["instances"]:
-            instance["iid"] = api.common.hash(instance["instance_number"] + sid + problem["name"])
-
 def load_problems_from_server(sid):
     """
     Connects to the server and loads the problems from its deployment state.
@@ -220,7 +211,9 @@ def load_problems_from_server(sid):
     result = shell.run(["sudo", "shell_manager", "publish"])
     data = json.loads(result.output.decode("utf-8"))
 
-    set_instance_ids(data["problems"])
+    #Pass along the server
+    data["sid"] = sid
+
     api.problem.load_published(data)
 
     return len(data["problems"])

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -190,7 +190,6 @@ def load_problems_from_server(sid):
 
     server = get_server(sid)
     shell = get_connection(server['host'], server['port'], server['username'], server['password'])
-    ensure_setup(shell)
 
     result = shell.run(["sudo", "shell_manager", "publish"])
     data = json.loads(result.output.decode("utf-8"))

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -4,17 +4,20 @@ import spur
 import json
 
 from api.common import validate, check, WebException
-from voluptuous import Schema, Required
+from voluptuous import Schema, Required, Length
 
 server_schema = Schema({
+    Required("name"): check(
+        ("Host must be a reasonable string.", [str, Length(min=1, max=128)])),
     Required("host"): check(
-        ("Host must be a string", [str])),
+        ("Host must be a reasonable string", [str, Length(min=1, max=128)])),
     Required("port"): check(
-        ("Port must be a string", [str])),
+        ("You have to supply a valid integer for your port.", [int]),
+        ("Your port number must be in the valid range 1-65535.", [lambda x: 1 <= int(x) and int(x) <= 65535])),
     Required("username"): check(
-        ("Username must be a string", [str])),
+        ("Username must be a reasonable string", [str, Length(min=1, max=128)])),
     Required("password"): check(
-        ("Username must be a string", [str])),
+        ("Username must be a reasonable string", [str, Length(min=1, max=128)])),
     Required("protocol"): check(
         ("Protocol must be either HTTP or HTTPS", [lambda x: x in ['HTTP', 'HTTPS']]))
 }, extra=True)

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -82,6 +82,7 @@ def add_server(params):
 
     return params["sid"]
 
+#Probably do not need/want the sid here anymore.
 def update_server(sid, params):
     """
     Update a shell server from the pool of servers.
@@ -96,7 +97,10 @@ def update_server(sid, params):
 
     db = api.common.get_conn()
 
-    if db.shell_servers.find_one({"sid": sid}) is None:
+    validate(server_schema, params)
+
+    server = safe_fail(get_server, name=params["name"])
+    if server is not None:
         raise WebException("Shell server with sid '{}' does not exist.".format(sid))
 
     validate(server_schema, params)
@@ -104,7 +108,7 @@ def update_server(sid, params):
     if isinstance(params["port"], str):
         params["port"] = int(params["port"])
 
-    db.shell_servers.update({"sid": sid}, {"$set": params})
+    db.shell_servers.update({"sid": server["sid"]}, {"$set": params})
 
 def remove_server(sid):
     """

--- a/web/coffee/management-shell.coffee
+++ b/web/coffee/management-shell.coffee
@@ -187,14 +187,11 @@ ShellServerTab = React.createClass
     <Well>
       <Grid>
         <Row>
-          <h4>To add problems, either enter your shell server information on the left or paste your published JSON on the right.</h4>
+          <h4>To add problems, either enter your shell server information on the left.</h4>
         </Row>
         <Row>
           <Col md={6}>
             <ShellServerList />
-          </Col>
-          <Col md={6} className="pull-right">
-            <ProblemLoaderTab/>
           </Col>
         </Row>
       </Grid>

--- a/web/coffee/management-shell.coffee
+++ b/web/coffee/management-shell.coffee
@@ -53,7 +53,7 @@ ServerForm = React.createClass
 
   updateName: (e) ->
     copy = @state.shellServer
-    copy.namet = e.target.value
+    copy.name = e.target.value
     @setState {shellServer: copy}
 
   updatePort: (e) ->
@@ -99,7 +99,7 @@ ServerForm = React.createClass
         </ButtonToolbar>
 
     <div>
-      <TextEntry name="Name" type="text" value={@state.shellServer.name} onChange=@updateName description={nameDescription} />
+      {if @props.new then <TextEntry name="Name" type="text" value={@state.shellServer.name} onChange=@updateName description={nameDescription}/> else <span/>}
       <TextEntry name="Host" type="text" value={@state.shellServer.host} onChange=@updateHost description={hostDescription} />
       <TextEntry name="SSH Port" type="number" value={@state.shellServer.port.toString()} onChange=@updatePort description={portDescription} />
       <TextEntry name="Username" type="text" value={@state.shellServer.username} onChange=@updateUsername description={usernameDescription} />

--- a/web/coffee/management-shell.coffee
+++ b/web/coffee/management-shell.coffee
@@ -15,7 +15,7 @@ ServerForm = React.createClass
 
   getInitialState: ->
     if @props.new
-      server = {"host":"", "port":22, "username":"", "password":"", "protocol": "HTTP"}
+      server = {"host": "", "port":22, "username": "", "password": "", "protocol": "HTTP", "name": ""}
     else
       server = @props.server
 
@@ -51,6 +51,11 @@ ServerForm = React.createClass
     copy.host = e.target.value
     @setState {shellServer: copy}
 
+  updateName: (e) ->
+    copy = @state.shellServer
+    copy.namet = e.target.value
+    @setState {shellServer: copy}
+
   updatePort: (e) ->
     copy = @state.shellServer
     copy.port = parseInt(e.target.value)
@@ -72,10 +77,11 @@ ServerForm = React.createClass
     @setState {shellServer: copy}
 
   render: ->
-    hostDescription = "The host name of your shell server"
-    portDescription = "The port that SSH is running on"
+    nameDescription = "A unique name given to this shell server."
+    hostDescription = "The host name of your shell server."
+    portDescription = "The port that SSH is running on."
     usernameDescription = "The username to connect as - Be sure that this user has sudo privileges!"
-    passwordDescription = "The password to use for authentication - Be sure that this is password is only used once"
+    passwordDescription = "The password to use for authentication - Be sure that this is password is only used once."
     protocolDescription = "The web protocol to access the problem files and shell server. This is most often just HTTP."
 
     if @state.new
@@ -93,6 +99,7 @@ ServerForm = React.createClass
         </ButtonToolbar>
 
     <div>
+      <TextEntry name="Name" type="text" value={@state.shellServer.name} onChange=@updateName description={nameDescription} />
       <TextEntry name="Host" type="text" value={@state.shellServer.host} onChange=@updateHost description={hostDescription} />
       <TextEntry name="SSH Port" type="number" value={@state.shellServer.port.toString()} onChange=@updatePort description={portDescription} />
       <TextEntry name="Username" type="text" value={@state.shellServer.username} onChange=@updateUsername description={usernameDescription} />
@@ -121,7 +128,7 @@ ShellServerList = React.createClass
       header = <div> New Shell Server </div>
     else
       shellServer = <ServerForm new={false} server={server} key={server.sid} refresh={@refresh}/>
-      header = <div> {server.host} </div>
+      header = <div>{server.name} - {server.host}</div>
 
     <Panel bsStyle={"default"} eventKey={i} key={i} header={header}>
       {shellServer}


### PR DESCRIPTION
Assigning names to shell servers to namespace instances. We also no longer force status checks before loading the deployment information. The status checks can take a very long time so we want to disentangle the process from loading the deployment information.

This removes the "paste json deployment" feature temporarily. I feel like removing it permanently in favor of a staging area for loaded deployments.