### PR TITLE
Option to hide groups

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -11,7 +11,7 @@ group_settings_schema = Schema({
     Required("email_filter"): check(
         ("Email filter must be a list of emails.", [lambda emails: type(emails) == list])),
     Required("hidden"): check(
-        ("Hidden property of a group is a boolean.", [bool]))})
+        ("Hidden property of a group is a boolean.", [lambda hidden: type(hidden) == bool]))})
 
 def get_roles_in_group(gid, tid=None, uid=None):
     """
@@ -172,6 +172,9 @@ def change_group_settings(gid, settings):
     validate(group_settings_schema, settings)
 
     group = api.group.get_group(gid=gid)
+    if group["settings"]["hidden"] and not settings["hidden"]:
+        raise InternalException("You can not change a hidden group back to a public group.")
+
     db.groups.update({"gid": group["gid"]}, {"$set": {"settings": settings}})
 
 

--- a/api/group.py
+++ b/api/group.py
@@ -5,6 +5,15 @@ import api
 from api.annotations import log_action
 from api.common import check, validate, safe_fail, InternalException
 
+from voluptuous import Required, Length, Schema
+
+group_settings_schema = Schema({
+    Required("email_filter"): check(
+        ("Email filter must be a list of emails.", lambda emails: type(emails) == list)),
+    Required("hidden"): check(
+        ("Hidden property of a group is a boolean.", bool))
+})
+
 def get_roles_in_group(gid, tid=None, uid=None):
     """
     Determine what role the team plays in a group.
@@ -133,7 +142,8 @@ def create_group(tid, group_name):
         "teachers": [],
         "members": [],
         "settings": {
-          "email_filter": []
+            "email_filter": [],
+            "hidden": False
         },
         "gid": gid
     })
@@ -160,6 +170,7 @@ def change_group_settings(gid, settings):
 
     db = api.common.get_conn()
 
+    validate(group_settings_schema, settings)
     group = api.group.get_group(gid=gid)
     db.groups.update({"gid": group["gid"]}, {"$set": {"settings": settings}})
 

--- a/api/group.py
+++ b/api/group.py
@@ -9,10 +9,9 @@ from voluptuous import Required, Length, Schema
 
 group_settings_schema = Schema({
     Required("email_filter"): check(
-        ("Email filter must be a list of emails.", lambda emails: type(emails) == list)),
+        ("Email filter must be a list of emails.", [lambda emails: type(emails) == list])),
     Required("hidden"): check(
-        ("Hidden property of a group is a boolean.", bool))
-})
+        ("Hidden property of a group is a boolean.", [bool]))})
 
 def get_roles_in_group(gid, tid=None, uid=None):
     """
@@ -171,6 +170,7 @@ def change_group_settings(gid, settings):
     db = api.common.get_conn()
 
     validate(group_settings_schema, settings)
+
     group = api.group.get_group(gid=gid)
     db.groups.update({"gid": group["gid"]}, {"$set": {"settings": settings}})
 

--- a/web/coffee/classroom-management.coffee
+++ b/web/coffee/classroom-management.coffee
@@ -122,6 +122,7 @@ GroupManagement = React.createClass
     name: ""
     settings:
       email_filter: []
+      hidden: false
     member_information: []
     teacher_information: []
     current_user: {}
@@ -171,8 +172,41 @@ GroupManagement = React.createClass
           memberInformation={@state.member_information} gid={@props.gid} refresh={@refreshSettings}/>
       </Col>
       <Col xs={6}>
+        <GroupOptions pushUpdates={@pushUpdates} settings={@state.settings} gid={@props.gid}/>
         <GroupEmailWhitelist emails={@state.settings.email_filter} pushUpdates={@pushUpdates} gid={@props.gid}/>
       </Col>
+    </div>
+
+GroupOptions = React.createClass
+  propTypes:
+    settings: React.PropTypes.object.isRequired
+    pushUpdates: React.PropTypes.func.isRequired
+    gid: React.PropTypes.string.isRequired
+
+  promptGroupHide: ->
+    window.confirmDialog "Hiding your group from the scoreboard is an irrevocable change. You won't be able to change this later.", "Hidden Group Change",
+    "Okay", "Cancel", (() ->
+      @props.pushUpdates ((data) -> update data, {hidden: {$set: true}})
+    ).bind this, () -> false
+
+  render: ->
+    if @props.settings.hidden
+      hiddenGroupDisplay =
+        <p>This group is <b>hidden</b> from the general scoreboard.</p>
+    else
+      hiddenGroupDisplay =
+        <p>
+          This group is <b>visible</b> on the scoreboard.
+          Click <a href="#" onClick={@promptGroupHide}>here</a> to hide it.
+        </p>
+
+    <div>
+      <h4>Group Options</h4>
+      <Panel>
+        <form>
+          {hiddenGroupDisplay}
+        </form>
+      </Panel>
     </div>
 
 EmailWhitelistItem = React.createClass
@@ -232,14 +266,12 @@ GroupEmailWhitelist = React.createClass
 
     <div>
       <h4>Email Domain Whitelist</h4>
-      <form onSubmit={@addEmailDomain}>
-        <Row>
-          <Input type="text" addonBefore="@ Domain" valueLink={@linkState "emailDomain"}/>
-        </Row>
-        <Row>
-          {if @props.emails.length > 0 then @createItemDisplay() else emptyItemDisplay}
-        </Row>
-      </form>
+        <Panel>
+          <form onSubmit={@addEmailDomain}>
+            <Input type="text" addonBefore="@ Domain" valueLink={@linkState "emailDomain"}/>
+            {if @props.emails.length > 0 then @createItemDisplay() else emptyItemDisplay}
+          </form>
+        </Panel>
     </div>
 
 TeacherManagement = React.createClass


### PR DESCRIPTION
This pull request fixes a few styling issues, resolves a group registration bug, and resolves #27 by giving group staff the ability to opt their group out of the public scoreboard.