### PR TITLE
affiliation is stored with the team not the user

### DIFF
--- a/api/team.py
+++ b/api/team.py
@@ -123,7 +123,7 @@ def create_new_team_request(params, uid=None):
         "team_name": params["team_name"],
         "password": params["team_password"],
         # The team's affiliation becomes the creator's affiliation.
-        "affiliation": user["affiliation"],
+        "affiliation": current_team["affiliation"],
         "eligible": True
     })
 


### PR DESCRIPTION
This fixes a bug on team creation where the api attempted to copy the
affiliation from a user rather than that user's  "personal team".