### PR TITLE
Initial travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+# versions of python to test on
+python:
+  - "3.4"
+  - "3.5"
+
+services:
+  - mongodb
+
+install:
+  - ./install.sh
+
+script: py.test unit_tests


### PR DESCRIPTION
A very basic configuration that runs the existing unit tests

Once #34 and #35 are merged this should give all unit-tests should pass and then we can flick the switch on https://travis-ci.org (Free for open-source).

This will give us an experience like https://travis-ci.org/royragsdale/picoCTF-web to not only verify master is passing tests, but also for pull requests as well.  Though this only covers the unit tests it can be expanded to cover the functional tests using headless selenium.