### PR TITLE
Problems can now be decreased to zero instances.

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -49,8 +49,12 @@ def set_problem_availability(pid, disabled):
         The updated problem object.
     """
 
-    result = api.problem.update_problem(pid, {"disabled": disabled})
-    api.cache.clear_all()
+    problem = api.problem.get_problem(pid=pid)
+    if len(problem["instances"]) > 0:
+        result = api.problem.update_problem(pid, {"disabled": disabled})
+        api.cache.clear_all()
+    else:
+        raise WebException("You cannnot change the availability of \"{}\".".format(problem["name"]))
     return result
 
 def get_api_exceptions(result_limit=50, sort_direction=pymongo.DESCENDING):

--- a/api/problem.py
+++ b/api/problem.py
@@ -90,7 +90,9 @@ bundle_schema = Schema({
     "dependencies": check(
         ("The bundle dependencies must be a dict.", [dict])),
     "dependencies_enabled": check(
-        ("The dependencies enabled state must be a bool.", [lambda x: type(x) == bool]))
+        ("The dependencies enabled state must be a bool.", [lambda x: type(x) == bool])),
+    "pkg_dependencies": check(
+        ("The package dependencies must be a list.", [lambda x: type(x) == list]))
 })
 
 DEBUG_KEY = None
@@ -158,7 +160,6 @@ def insert_problem(problem, sid=None):
     if safe_fail(get_problem, pid=problem["pid"]) is not None:
         # problem is already inserted, so update instead
         old_problem = copy(get_problem(pid=problem["pid"]))
-        problem["disabled"] = old_problem["disabled"]
 
         # leave all instances from different shell server
         instances = list(filter(lambda i: i["sid"] != sid, old_problem["instances"]))
@@ -166,6 +167,9 @@ def insert_problem(problem, sid=None):
         # add instances from this shell server
         instances.extend(problem["instances"])
         problem["instances"] = instances
+
+        # disable problems with zero instances
+        problem["disabled"] = old_problem["disabled"] or len(problem["instances"]) == 0
 
         # run the update
         update_problem(problem["pid"], problem)

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -13,7 +13,8 @@ blueprint = Blueprint("admin_api", __name__)
 @api_wrapper
 @require_admin
 def get_problem_data_hook():
-    problems =  api.problem.get_all_problems(show_disabled=True)
+    has_instances = lambda p : len(p["instances"]) > 0
+    problems = list(filter(has_instances, api.problem.get_all_problems(show_disabled=True)))
 
     for problem in problems:
         problem["reviews"] = api.problem_feedback.get_problem_feedback(pid=problem["pid"])

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -218,4 +218,5 @@ def load_problems_from_server(sid):
 
     api.problem.load_published(data)
 
-    return len(data["problems"])
+    has_instances = lambda p : len(p["instances"]) > 0
+    return len(list(filter(has_instances, data["problems"])))


### PR DESCRIPTION
They will be set to disabled and hidden from the admin page while they continue to have zero instances. This is effectively removing the problem from the competition, but also allowing us to not break internal requirements on the problem's existence in the database.

This change requires [PR #62](https://github.com/picoCTF/picoCTF-shell-manager/pull/62) from the shell_manager.

Resolves [#60](https://github.com/picoCTF/picoCTF-shell-manager/issues/60).