### PR TITLE
Add Symlinking Daemon

### DIFF
--- a/api/problem.py
+++ b/api/problem.py
@@ -450,31 +450,6 @@ def count_submissions(pid=None, uid=None, tid=None, category=None, correctness=N
 
     return db.submissions.find(match, {"_id": 0}).count()
 
-def get_most_recent_submission(uid=None, tid=None, correctness=None):
-    """
-    Gets the most recent submission from a team or user.
-    """
-
-    db = api.common.get_conn()
-
-    match = {}
-
-    if uid is not None:
-        match.update({"uid": uid})
-    elif tid is not None:
-        match.update({"tid": tid})
-    else:
-        raise InternalException("You have to supply a uid or tid.")
-
-    if correctness is not None:
-        match.update({"correct": correctness})
-
-    #pymongo is awkward
-    submission = list(db.submissions.find(match).sort('timestamp', pymongo.DESCENDING).limit(1))
-
-    if len(submission) == 1:
-        return submission[0]
-
 
 def get_submissions(pid=None, uid=None, tid=None, category=None, correctness=None, eligibility=None):
     """

--- a/api/problem.py
+++ b/api/problem.py
@@ -450,6 +450,31 @@ def count_submissions(pid=None, uid=None, tid=None, category=None, correctness=N
 
     return db.submissions.find(match, {"_id": 0}).count()
 
+def get_most_recent_submission(uid=None, tid=None, correctness=None):
+    """
+    Gets the most recent submission from a team or user.
+    """
+
+    db = api.common.get_conn()
+
+    match = {}
+
+    if uid is not None:
+        match.update({"uid": uid})
+    elif tid is not None:
+        match.update({"tid": tid})
+    else:
+        raise InternalException("You have to supply a uid or tid.")
+
+    if correctness is not None:
+        match.update({"correct": correctness})
+
+    #pymongo is awkward
+    submission = list(db.submissions.find(match).sort('timestamp', pymongo.DESCENDING).limit(1))
+
+    if len(submission) == 1:
+        return submission[0]
+
 
 def get_submissions(pid=None, uid=None, tid=None, category=None, correctness=None, eligibility=None):
     """

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -22,18 +22,46 @@ server_schema = Schema({
         ("Protocol must be either HTTP or HTTPS", [lambda x: x in ['HTTP', 'HTTPS']]))
 }, extra=True)
 
-def get_connection(host, port, username, password):
+def get_server(sid=None, name=None):
+    """
+    Returns the server object corresponding to the sid provided
+
+    Args:
+        sid: the server id to lookup
+
+    Returns:
+        The server object
+    """
+
+    db = api.common.get_conn()
+
+    if sid is None:
+        if name is None:
+            raise InternalException("You must specify either an sid or name")
+        else:
+            sid = api.common.hash(name)
+
+    server = db.shell_servers.find_one({"sid": sid})
+    if server is None:
+        raise InternalException("Server with sid '{}' does not exist".format(sid))
+
+    return server
+
+def get_connection(sid):
     """
     Attempts to connect to the given server and
     returns a connection.
     """
 
+
+    server = get_server(sid)
+
     try:
         shell = spur.SshShell(
-            hostname=host,
-            username=username,
-            password=password,
-            port=port,
+            hostname=server["host"],
+            username=server["username"],
+            password=server["password"],
+            port=server["port"],
             missing_host_key=spur.ssh.MissingHostKey.accept,
             connect_timeout=10
         )
@@ -127,31 +155,6 @@ def remove_server(sid):
 
     db.shell_servers.remove({"sid": sid})
 
-def get_server(sid=None, name=None):
-    """
-    Returns the server object corresponding to the sid provided
-
-    Args:
-        sid: the server id to lookup
-
-    Returns:
-        The server object
-    """
-
-    db = api.common.get_conn()
-
-    if sid is None:
-        if name is None:
-            raise InternalException("You must specify either an sid or name")
-        else:
-            sid = api.common.hash(name)
-
-    server = db.shell_servers.find_one({"sid": sid})
-    if server is None:
-        raise InternalException("Server with sid '{}' does not exist".format(sid))
-
-    return server
-
 def get_servers():
     """
     Returns the list of added shell servers.
@@ -174,8 +177,7 @@ def get_problem_status_from_server(sid):
             - The output data of shell_manager status --json
     """
 
-    server = get_server(sid)
-    shell = get_connection(server['host'], server['port'], server['username'], server['password'])
+    shell = get_connection(sid)
     ensure_setup(shell)
 
     output = shell.run(["sudo", "shell_manager", "status", "--json"]).output.decode("utf-8")
@@ -207,8 +209,7 @@ def load_problems_from_server(sid):
         The number of problems loaded
     """
 
-    server = get_server(sid)
-    shell = get_connection(server['host'], server['port'], server['username'], server['password'])
+    shell = get_connection(sid)
 
     result = shell.run(["sudo", "shell_manager", "publish"])
     data = json.loads(result.output.decode("utf-8"))

--- a/api/shell_servers.py
+++ b/api/shell_servers.py
@@ -67,7 +67,8 @@ def get_connection(sid):
         )
         shell.run(["echo", "connected"])
     except spur.ssh.ConnectionError as e:
-        raise WebException("Cannot connect to {}@{}:{} with the specified password".format(username, host, port))
+        raise WebException("Cannot connect to {}@{}:{} with the specified password".format(
+            server["username"], server["host"], server["port"]))
 
     return shell
 

--- a/daemons/share_instances.py
+++ b/daemons/share_instances.py
@@ -87,7 +87,7 @@ def add_symlinks(sid, user, to_add):
             shell.run(["sudo", "ln", "-s", path, symlink])
             print("Added symlink %s --> %s" % (symlink, path))
         except spur.results.RunProcessError as e:
-            print("Failed to add symlink %s->%s" % (symlink, path))
+            print("Failed to add symlink %s --> %s" % (symlink, path))
 
 def run():
     global connections

--- a/daemons/share_instances.py
+++ b/daemons/share_instances.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+import api
+
+"""
+teams = api.teams.filter(score > 0)
+for server in api.shell_servers.get_online_servers():
+  shell = server.get_ssh()
+  for team in teams:
+    current_head = db.submission_heads.find(tid)
+    most_recent_sub = db.submissions.get_most_recent(tid)
+
+    if current_head is None or current_head < most_recent_sub:
+      unlocked_problems = api.problems.get_unlocked(team)
+
+      for user in team.get_enabled_users():
+        user_sym_links = shell.get_sym_links(user)
+        additional_sym_links = unlocked_problems / user_sym_links
+        removable_sym_links = user_sym_links / unlocked_problems
+
+        shell.sym_links.add(user, additional_sym_links)
+        shell.sym_links.remove(user, removable_sym_links)
+"""
+
+def run():
+    db = api.common.get_conn()
+
+    teams = api.team.get_all_teams(show_ineligible=True)
+
+    for server in api.shell_servers.get_servers():
+        shell = api.shell_servers.get_connection(server["sid"])
+
+        submission_heads = db.submission_heads.find_one({"sid": server["sid"]})
+        if submission_heads is None:
+            db.submission_heads.insert({"sid": server["sid"], "heads": {}})
+            submission_heads = db.submission_heads.find_one({"sid": server["sid"]})
+
+        submission_heads = submission_heads["heads"]
+        for team in teams:
+            submission = api.problem.get_most_recent_submission(tid=team["tid"], correctness=True)
+            team_head_pid = submission_heads.get(team["tid"], None)
+            if submission is not None and (team_head_pid is None or submission["pid"] != team_head_pid):
+                print("Team '%s' is outdated. %s -> %s" % (team["team_name"], team_head_pid, submission["pid"]))
+
+                unlocked_problems = api.problem.get_unlocked_problems(tid=team["tid"])
+
+                db.submission_heads.update({"sid": server["sid"]}, {"$set": {"heads."+team["tid"]: submission["pid"]}})
+            else:
+                print("Team '%s' up-to-date." % team["team_name"])
+
+

--- a/daemons/share_instances.py
+++ b/daemons/share_instances.py
@@ -87,7 +87,8 @@ def run():
         data = {}
         for team in teams:
             unlocked_problems = api.problem.get_unlocked_problems(tid=team["tid"])
-            correct_symlinks = {p["name"]:p["deployment_directory"] for p in unlocked_problems if p["should_symlink"]}
+            correct_symlinks = {p["name"]:p["deployment_directory"] for p in unlocked_problems if p["should_symlink"]
+                                                                                              and p["sid"] == server["sid"]}
 
             data.update({user["username"]:correct_symlinks for user in api.team.get_team_members(tid=team["tid"])})
 

--- a/daemons/share_instances.py
+++ b/daemons/share_instances.py
@@ -1,51 +1,128 @@
 #!/usr/bin/python3
 
 import api
+import spur
+import time
+from os.path import join
 
-"""
-teams = api.teams.filter(score > 0)
-for server in api.shell_servers.get_online_servers():
-  shell = server.get_ssh()
-  for team in teams:
-    current_head = db.submission_heads.find(tid)
-    most_recent_sub = db.submissions.get_most_recent(tid)
+def cache(f, *args, **kwargs):
+    result = f(cache=False, *args, **kwargs)
+    key = api.cache.get_mongo_key(f, *args, **kwargs)
+    api.cache.set(key, result)
+    return result
 
-    if current_head is None or current_head < most_recent_sub:
-      unlocked_problems = api.problems.get_unlocked(team)
+class CantConnectException(Exception):
+    pass
 
-      for user in team.get_enabled_users():
-        user_sym_links = shell.get_sym_links(user)
-        additional_sym_links = unlocked_problems / user_sym_links
-        removable_sym_links = user_sym_links / unlocked_problems
+# open shell server connections
+connections = {}
 
-        shell.sym_links.add(user, additional_sym_links)
-        shell.sym_links.remove(user, removable_sym_links)
-"""
+def get_connection(sid):
+    global connections
+    if connections.get(sid, None) == None:
+        try:
+            connections[sid] = api.shell_servers.get_connection(sid)
+        except api.common.WebException as e:
+            raise CantConnectException
+    return connections[sid]
+
+def get_home_dir(shell, user):
+    # first make sure the user has an account
+    if shell.run(["id", "-u", user], allow_error=True).return_code != 0:
+        return None
+
+    home_dir = shell.run(["bash", "-c", "echo ~%s" % user]).output.decode("utf-8").strip()
+
+    return home_dir
+
+@api.cache.memoize()
+def get_symlinks(sid, user):
+    shell = get_connection(sid)
+
+    home_dir = get_home_dir(shell, user)
+    if home_dir == None:
+        return None
+
+    problems_path = join(home_dir, "problems")
+    try:
+        result = shell.run(["sudo", "ls", problems_path]).output.decode("utf-8")
+        return result.split("\n")[:-1]
+    except spur.results.RunProcessError as e:
+        # directory must not exist
+        result = shell.run(["sudo", "mkdir", problems_path], allow_error=True)
+        if result.return_code != 0:
+            # something else is wrong, so give up
+            return None
+
+        # try again
+        get_symlinks(shell, user)
+
+def rm_symlinks(sid, user, to_remove):
+    shell = get_connection(sid)
+
+    home_dir = get_home_dir(shell, user)
+    if home_dir == None:
+        return None
+
+    problems_path = join(home_dir, "problems")
+    for name in to_remove:
+        symlink = join(problems_path, name)
+        try:
+            shell.run(["sudo", "rm", symlink])
+            print("Removed symlink %s" % symlink)
+        except spur.results.RunProcessError as e:
+            print("Failed to remove symlink %s" % symlink)
+
+def add_symlinks(sid, user, to_add):
+    shell = get_connection(sid)
+
+    home_dir = get_home_dir(shell, user)
+    if home_dir == None:
+        return None
+
+    problems_path = join(home_dir, "problems")
+    for name, path in to_add.items():
+        symlink = join(problems_path, name)
+        try:
+            shell.run(["sudo", "ln", "-s", path, symlink])
+            print("Added symlink %s --> %s" % (symlink, path))
+        except spur.results.RunProcessError as e:
+            print("Failed to add symlink %s->%s" % (symlink, path))
 
 def run():
-    db = api.common.get_conn()
+    global connections
 
     teams = api.team.get_all_teams(show_ineligible=True)
 
     for server in api.shell_servers.get_servers():
-        shell = api.shell_servers.get_connection(server["sid"])
 
-        submission_heads = db.submission_heads.find_one({"sid": server["sid"]})
-        if submission_heads is None:
-            db.submission_heads.insert({"sid": server["sid"], "heads": {}})
-            submission_heads = db.submission_heads.find_one({"sid": server["sid"]})
-
-        submission_heads = submission_heads["heads"]
-        for team in teams:
-            submission = api.problem.get_most_recent_submission(tid=team["tid"], correctness=True)
-            team_head_pid = submission_heads.get(team["tid"], None)
-            if submission is not None and (team_head_pid is None or submission["pid"] != team_head_pid):
-                print("Team '%s' is outdated. %s -> %s" % (team["team_name"], team_head_pid, submission["pid"]))
-
+        try:
+            for team in teams:
                 unlocked_problems = api.problem.get_unlocked_problems(tid=team["tid"])
+                correct_symlinks = {p["name"]:p["deployment_directory"] for p in unlocked_problems if p["should_symlink"]}
+                correct_names = set(correct_symlinks.keys())
 
-                db.submission_heads.update({"sid": server["sid"]}, {"$set": {"heads."+team["tid"]: submission["pid"]}})
-            else:
-                print("Team '%s' up-to-date." % team["team_name"])
+                for user in api.team.get_team_members(tid=team["tid"]):
+                    start = time.time()
+                    current_symlinks = get_symlinks(server["sid"], user["username"])
+                    if current_symlinks == None:
+                        continue
 
+                    symlinked_names = set(current_symlinks)
+                    to_add = correct_names - symlinked_names
+                    to_remove = symlinked_names - correct_names
 
+                    if len(to_add) > 0:
+                        add_symlinks(server["sid"], user["username"], {name:correct_symlinks[name] for name in to_add})
+                    if len(to_remove) > 0:
+                        rm_symlinks(server["sid"], user["username"], to_remove)
+
+                    if len(to_add) > 0 or len(to_remove) > 0:
+                        cache(get_symlinks, server["sid"], user["username"])
+
+                    print("Took %.2f seconds." % (time.time() - start))
+
+        except CantConnectException as e:
+            print("Couldn't connect to server \"%s\"" % server["name"])
+
+        connections[server["sid"]] = None

--- a/daemons/share_instances.py
+++ b/daemons/share_instances.py
@@ -117,7 +117,7 @@ def run():
             result = process.wait_for_result()
             output = result.output.decode('utf-8')
             if output == "":
-                print("Everthing up to date")
+                print("Everything up to date")
             else:
                 print(output)
         except api.common.WebException as e:


### PR DESCRIPTION
This PR adds a daemon that is not currently on by default. For all challenges that require local access on the shell server and for each user that has the problem unlocked, this daemon will add symbolic links to the their assigned instance in `$HOME/problems/`

For performance reasons, we send a temporary script over to the server that will manage the symlinks, and then provide it the data it needs.

Security wise, the directory `$HOME/problems/` is owned by `root:root` with the `chattr -u` flag. This prevents the user from deleting or moving the directory.